### PR TITLE
10_IT: userV1setCodes werden auch für den Empfang verwendet

### DIFF
--- a/FHEM/10_IT.pm
+++ b/FHEM/10_IT.pm
@@ -6,7 +6,7 @@
 # 
 # Published under GNU GPL License
 #
-# $Id: 10_IT.pm 19761 2019-10-30 18:00:03Z Ralf9 $
+# $Id: 10_IT.pm 19761 2019-11-07 12:00:00Z Ralf9 $
 #
 ######################################################
 package main;
@@ -1367,6 +1367,7 @@ sub IT_Attr(@)
    <li>optional <code>&lt;dimup-code&gt; &lt;dimdown-code&gt;</code>  2 numbers in quad state format (0/1/F/D), 
    contains the command for dimming; 
      this number is added to the &lt;housecode&gt; to define tha actual 12-number sending command.</li>
+   <li>If the attribute userV1setCodes exists, these codes are also used for reception, the userV1setCodes have priority over the XMIT Codes.</li>
    <li>Notice: orginal ITv1 devices are only defined using the on command.</li>
    <li>Devices which are nt orignal ITv1 devices cen be defined as follows:</li><br>
        To autocreate press twice "on" within 30 seconds. The Log gives:<br>
@@ -1529,8 +1530,8 @@ Examples:
 
           <b>Dimmer</b>: itdimmer<br>
 
-          <b>door/window contact (china)</b>: itswitch_CHN<br>
-					
+          <b>door/window contact (china)</b>: itswitch_CHN (closed:1110 open:1010 tamper:0111)<br>
+
           <b>Receiver/Actor</b>: itswitch<br>
 
           <b>EV1527</b>: ev1527
@@ -1572,10 +1573,13 @@ Examples:
 
     <a name="userV1setCodes"></a>
      <li>userV1setCodes<br>
-       If an ITv1 protocol is used indivual setcodes can be added. Example:
+       If an ITv1 protocol is used indivual setcodes can be added.<br>
+       The setcodes are also used for reception, the userV1setCodes have priority over the XMIT Codes.<br>
+       Example:
        <ul><code>
        attr lamp userV1setCodes red:FD blue:1F<br>
-       attr lamp userV1setCodes up:1001 down:1000 stop:1011
+       attr lamp userV1setCodes up:1001 down:1000 stop:1011<br>
+       attr IT_1527x12345 userV1setCodes closed:0111 open:1110 tamper:1011 lowVoltage:1111  # Kerui magnetic contact sensors
        </code></ul>
     </li><br>
     
@@ -1820,7 +1824,7 @@ Beispiele:
         <b>Dimmer</b>: itdimmer<br>
 
         <b>T&uuml;r/Fensterkontakt (China)</b>: itswitch_CHN (closed:1110 open:1010 tamper:0111)<br>
-				
+
         <b>Empf&auml;nger/Actor</b>: itswitch<br>
 
         <b>EV1527</b>: ev1527
@@ -1867,7 +1871,8 @@ Beispiele:
        Beispiele:
        <ul><code>
        attr lamp userV1setCodes rot:FD blau:1F<br>
-       attr lamp userV1setCodes hoch:1001 runter:1000 stop:1011
+       attr lamp userV1setCodes hoch:1001 runter:1000 stop:1011<br>
+       attr IT_1527x12345 userV1setCodes closed:0111 open:1110 tamper:1011 lowVoltage:1111  # Kerui Fensterkontakt
        </code></ul>
     </li><br>
     

--- a/FHEM/10_IT.pm
+++ b/FHEM/10_IT.pm
@@ -20,7 +20,7 @@ use SetExtensions;
 my %codes = (
   "XMIToff" => "off",
   "XMITon"  => "on", # Set to previous dim value (before switching it off)
-  "00" => "dimoff", # alt off
+  "00" => "dim00%", # alt off
   "01" => "dim06%",
   "02" => "dim12%",
   "03" => "dim18%",

--- a/FHEM/10_IT.pm
+++ b/FHEM/10_IT.pm
@@ -6,7 +6,7 @@
 # 
 # Published under GNU GPL License
 #
-# $Id: 10_IT.pm 19761 2019-10-19 18:37:03Z Ralf9 $
+# $Id: 10_IT.pm 19761 2019-10-20 18:37:03Z Ralf9 $
 #
 ######################################################
 package main;
@@ -1282,6 +1282,7 @@ sub IT_Attr(@)
 			$hash->{userV1setCodes} = undef;
 			$hash->{userV1setCodes}{open} = "1010";
 			$hash->{userV1setCodes}{closed} = "1110";
+			$hash->{userV1setCodes}{tamper} = "0111";
 		}
 	} elsif ( $aName eq 'userV1setCodes') {
 		my @array = split(" ",$aVal);

--- a/FHEM/10_IT.pm
+++ b/FHEM/10_IT.pm
@@ -6,7 +6,7 @@
 # 
 # Published under GNU GPL License
 #
-# $Id: 10_IT.pm 19761 2019-10-20 18:37:03Z Ralf9 $
+# $Id: 10_IT.pm 19761 2019-10-30 18:00:03Z Ralf9 $
 #
 ######################################################
 package main;
@@ -1278,7 +1278,6 @@ sub IT_Attr(@)
 			#Log3 $hash, 4, "$name IT_Attr: ev1527";
 			$hash->{READINGS}{protocol}{VAL}  = 'EV1527';
 		} elsif ($aVal eq 'itswitch_CHN') {
-			#$hash->{userV1setCodes} = ("open" => "1010", "closed" => "1110");
 			$hash->{userV1setCodes} = undef;
 			$hash->{userV1setCodes}{open} = "1010";
 			$hash->{userV1setCodes}{closed} = "1110";
@@ -1662,6 +1661,7 @@ Examples:
    <li>optional <code>&lt;dimup-code&gt; &lt;dimdown-code&gt;</code> jeweils 2 Ziffern lange quad-State-Zahl (0/1/F/D), 
    die den Befehl zum Herauf- und Herunterregeln enth&auml;lt; 
      die Zahl wird an den &lt;housecode&gt; angef&uuml;gt, um den 12-stelligen IT-Sendebefehl zu bilden.</li>
+   <li>Falls es das Attribut userV1setCodes gibt, werden diese Codes auch für den Empfang verwendet, dabei haben die userV1setCodes Vorrang vor den XMIT Codes.</li>
    <li>Hinweis: orginal ITv1 devices werden nur beim on Befehl angelegt.</li>
    <li>Die nicht orginal ITv1 devices k&ouml;nnen wie folgt angelegt werden:</li><br>
        Zum anlegen mit autocreate 2 mal auf "on" dr&uuml;cken:<br>
@@ -1819,7 +1819,7 @@ Beispiele:
 
         <b>Dimmer</b>: itdimmer<br>
 
-        <b>T&uuml;r/Fensterkontakt (China)</b>: itswitch_CHN<br>
+        <b>T&uuml;r/Fensterkontakt (China)</b>: itswitch_CHN (closed:1110 open:1010 tamper:0111)<br>
 				
         <b>Empf&auml;nger/Actor</b>: itswitch<br>
 
@@ -1862,7 +1862,9 @@ Beispiele:
     
     <a name="userV1setCodes"></a>
     <li>userV1setCodes<br>
-       Damit k&ouml;nnen beim ITv1 Protokoll eigene setcodes zugef&uuml;gt werden. Beispiele:
+       Damit k&ouml;nnen beim ITv1 Protokoll eigene setcodes zugef&uuml;gt werden.<br>
+       Die setcodes werden auch f&uuml;r den Empfang verwendet, dabei haben die userV1setCodes Vorrang vor den XMIT Codes.<br>
+       Beispiele:
        <ul><code>
        attr lamp userV1setCodes rot:FD blau:1F<br>
        attr lamp userV1setCodes hoch:1001 runter:1000 stop:1011

--- a/FHEM/10_IT.pm
+++ b/FHEM/10_IT.pm
@@ -637,13 +637,17 @@ IT_Set($@)
 	} else {
 		if ($hash->{READINGS}{protocol}{VAL} eq "V3") {
 			$protocolId = 'P17#';
+		} elsif ($hash->{READINGS}{protocol}{VAL} eq "HE800") {	# HomeEasy HE800
+			$protocolId = 'P35#';
+		} elsif ($hash->{READINGS}{protocol}{VAL} eq "HE_EU") {	# HomeEasy HE_EU
+			$protocolId = 'P65#';
 		} else {
 			$protocolId = 'P3#';  # IT V1
 		}
 	}
 	if ($hash->{READINGS}{protocol}{VAL} ne "EV1527" && $hash->{READINGS}{protocol}{VAL} ne "V1" && $hash->{READINGS}{protocol}{VAL} ne 'SBC_FreeTec') {  # bei ITv1, SBC_FreeTec und EV1527 wird das "is" am Anfang nicht entfernt
-		$message = substr($message,2);
-		if (substr($message,0,1) eq "h") {    # h entfernen falls am am Anfang
+		$message =~ s/^is//;
+		if ($message =~ m/^[he]/) {    # h oder e entfernen, falls am Anfang
 			$message = substr($message,1);
 		}
 	}


### PR DESCRIPTION
Die userV1setCodes werden auch für den Empfang verwendet, dabei haben die userV1setCodes Vorrang vor den XMIT Codes.
Beim model itswitch_CHN werden auch die userV1setCodes verwendet, die userV1setCodes werden automatisch definiert.
Beim %codes hash war off doppelt.